### PR TITLE
Add Wait/Notify

### DIFF
--- a/src/main/scala/SchedulerImp.scala
+++ b/src/main/scala/SchedulerImp.scala
@@ -8,26 +8,34 @@ class SchedulerImp(
 
   @volatile var running: Boolean = false
 
+  val taskRunner = new {
+    def run()(implicit ec: ExecutionContext): Unit = {
+      while (running) {
+        // put and take are blocking
+        val nextTask = minHeap.take()
+        val executionTime = nextTask.timestamp
+        if (executionTime < System.currentTimeMillis) {
+          Future {
+            nextTask.task()
+          }
+        } else {
+          minHeap.put(nextTask)
+          this.wait(executionTime)
+        }
+      }
+    }
+  }
+
   override def schedule(task: () => Unit, timestamp: Long): Unit = {
     minHeap.offer(ScheduledTask(task, timestamp))
+    taskRunner.notify()
   }
 
   override def start()(implicit ec: ExecutionContext): Unit = {
     if (!running) {
       running = true
       Future {
-        while (running) {
-          // put and take are blocking
-          val nextTask = minHeap.take()
-          if (nextTask.timestamp < System.currentTimeMillis) {
-            Future {
-              nextTask.task()
-            }
-          } else {
-            minHeap.put(nextTask)
-            Thread.sleep(100)
-          }
-        }
+        taskRunner.run()
       }
     }
   }


### PR DESCRIPTION
add wait/notify for consumer methods to avoid busy queue lookup
- Task runner is executing in a thread
- Notify the task runner when a task is inserted into the queue