### PR TITLE
Future promise - minor optimization

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "learning"
+name := "task-scheduler"
 
 version := "1.0"
 

--- a/src/main/scala/ScheduledTask.scala
+++ b/src/main/scala/ScheduledTask.scala
@@ -1,3 +1,3 @@
 import scala.concurrent.Promise
 
-case class ScheduledTask[T : Manifest](task: () => T, timestamp: Long, promise: Promise[T])
+case class ScheduledTask[T](task: () => T, timestamp: Long, promise: Promise[T])

--- a/src/main/scala/SchedulerImp.scala
+++ b/src/main/scala/SchedulerImp.scala
@@ -34,8 +34,15 @@ class SchedulerImp(
     val promise = Promise[T]()
 
     minHeap.offer(ScheduledTask(task, timestamp, promise))
-    taskRunner.synchronized {
-      taskRunner.notify()
+
+    if (!minHeap.isEmpty) {
+      val nextTask = minHeap.peek()
+
+      if (timestamp < nextTask.timestamp) {
+        taskRunner.synchronized {
+          taskRunner.notify()
+        }
+      }
     }
 
     promise.future

--- a/src/main/scala/SchedulerImp.scala
+++ b/src/main/scala/SchedulerImp.scala
@@ -17,7 +17,8 @@ class SchedulerImp(
         val interval = nextTask.timestamp - System.currentTimeMillis
         if (interval <= 0) {
           Future {
-            nextTask.promise.asInstanceOf[Promise[Any]].complete(Try(nextTask.task()))
+            val p = nextTask.promise.asInstanceOf[Promise[Any]]
+            p.complete(Try(nextTask.task()))
           }
         } else {
           minHeap.put(nextTask)


### PR DESCRIPTION
Dealing with an edge case - only notify when the inserted task's scheduled time is earlier than next task's in the queue. Resolved race condition: wait/notify is tricky.